### PR TITLE
Added a command to list indices

### DIFF
--- a/inc/Commands.php
+++ b/inc/Commands.php
@@ -41,17 +41,17 @@ class Commands extends WP_CLI_Command
      */
     public function list($args, $assoc_args)
     {
-      $indices = $this->indexRepository->all();
-      $list = [];
+        $indices = $this->indexRepository->all();
+        $list = [];
 
-      foreach ($indices as $key => $index) {
-        $list[] = [
-          'key' => $key,
+        foreach ($indices as $key => $index) {
+            $list[] = [
+          'key'  => $key,
           'name' => $index->getName()
         ];
-      }
+        }
 
-      WP_CLI\Utils\format_items( 'table', $list, array( 'key', 'name' ) );
+        WP_CLI\Utils\format_items('table', $list, ['key', 'name']);
     }
 
     /**

--- a/inc/Commands.php
+++ b/inc/Commands.php
@@ -28,6 +28,33 @@ class Commands extends WP_CLI_Command
     }
 
     /**
+     * List all available indices.
+     *
+     * ## EXAMPLES
+     *
+     *     wp algolia list
+     *
+     * @when before_wp_load
+     *
+     * @param mixed $args
+     * @param mixed $assoc_args
+     */
+    public function list($args, $assoc_args)
+    {
+      $indices = $this->indexRepository->all();
+      $list = [];
+
+      foreach ($indices as $key => $index) {
+        $list[] = [
+          'key' => $key,
+          'name' => $index->getName()
+        ];
+      }
+
+      WP_CLI\Utils\format_items( 'table', $list, array( 'key', 'name' ) );
+    }
+
+    /**
      * Push all records to Algolia for a given index.
      *
      * ## OPTIONS


### PR DESCRIPTION
Comme tu le suggérais j'ai ajouté une commande permettant de lister les index disponibles :

    $ wp algolia list
    +------------+------------------------+
    | key        | name                   |
    +------------+------------------------+
    | evenements | WP_dev_hans_evenements |
    | projets    | WP_dev_hans_projets    |
    +------------+------------------------+