### PR TITLE
projets: index categories names instead of slugs

### DIFF
--- a/inc/TelaBotanica/ActualiteRecordsProvider.php
+++ b/inc/TelaBotanica/ActualiteRecordsProvider.php
@@ -130,7 +130,7 @@ class ActualiteRecordsProvider extends WpQueryRecordsProvider
             return false;
         }
         $category_parent_id = $category[0]->category_parent;
-        if (! isset($category_actualites->cat_ID) || $category_actualites->cat_ID !== $category_parent_id) {
+        if (!isset($category_actualites->cat_ID) || $category_actualites->cat_ID !== $category_parent_id) {
             return false;
         }
 

--- a/inc/TelaBotanica/EvenementRecordsProvider.php
+++ b/inc/TelaBotanica/EvenementRecordsProvider.php
@@ -164,7 +164,7 @@ class EvenementRecordsProvider extends WpQueryRecordsProvider
             return false;
         }
         $category_parent_id = $category[0]->category_parent;
-        if (! isset($category_evenements->cat_ID) || $category_evenements->cat_ID !== $category_parent_id) {
+        if (!isset($category_evenements->cat_ID) || $category_evenements->cat_ID !== $category_parent_id) {
             return false;
         }
 

--- a/inc/TelaBotanica/ProjetRecordsProvider.php
+++ b/inc/TelaBotanica/ProjetRecordsProvider.php
@@ -36,7 +36,7 @@ class ProjetRecordsProvider extends BuddypressGroupRecordsProvider
             'object_dir' => 'groups',
             'item_id'    => $group->id
         ]);
-        $categories = array_map(function($category){
+        $categories = array_map(function ($category) {
             return bp_groups_get_group_type_object($category)->labels['name'];
         }, bp_groups_get_group_type($group->id, false) ?: []);
         $record['categories'] = ($categories === false ? [] : $categories);

--- a/inc/TelaBotanica/ProjetRecordsProvider.php
+++ b/inc/TelaBotanica/ProjetRecordsProvider.php
@@ -36,7 +36,9 @@ class ProjetRecordsProvider extends BuddypressGroupRecordsProvider
             'object_dir' => 'groups',
             'item_id'    => $group->id
         ]);
-        $categories = bp_groups_get_group_type($group->id, false);
+        $categories = array_map(function($category){
+            return bp_groups_get_group_type_object($category)->labels['name'];
+        }, bp_groups_get_group_type($group->id, false) ?: []);
         $record['categories'] = ($categories === false ? [] : $categories);
         $record['tela'] = bp_groups_has_group_type($group->id, 'tela-botanica');
         $record['archive'] = bp_groups_has_group_type($group->id, 'archive');


### PR DESCRIPTION
On indexe les noms des catégories (ex. `Tela Botanica`) plutôt que leurs "slugs" (ex. `tela-botanica`)